### PR TITLE
New settings for EXCH2 package

### DIFF
--- a/pkg_groups
+++ b/pkg_groups
@@ -12,7 +12,7 @@
 
 #  package "groups" definition (including default "default_pkg_list"):
 
-default_pkg_list : MER
+default_pkg_list : MER_EXCH2
 
 gfd : mom_common mom_fluxform mom_vecinv generic_advdiff debug mdsio rw monitor
 
@@ -23,3 +23,5 @@ atmospheric : gfd shap_filt
 adjoint : autodiff cost ctrl grdchk
 
 MER : gfd gmredi kpp ggl90 timeave obcs exf cal diagnostics ptracers gchem BFMcoupler longstep rbcs mnc
+
+MER_EXCH2 : gfd gmredi kpp ggl90 timeave obcs exf cal diagnostics ptracers gchem BFMcoupler longstep rbcs mnc exch2

--- a/presets/ION/SIZE.h_0487p_exch2
+++ b/presets/ION/SIZE.h_0487p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   43,
+     &           sNy =   32,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  487,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =  101)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/ION/SIZE.h_0643p_exch2
+++ b/presets/ION/SIZE.h_0643p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   43,
+     &           sNy =   24,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  643,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =  101)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/ION/SIZE.h_1276p_exch2
+++ b/presets/ION/SIZE.h_1276p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   16,
+     &           sNy =   32,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy = 1276,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =  101)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/LIG/SIZE.h_0226p_exch2
+++ b/presets/LIG/SIZE.h_0226p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (      
+     &           sNx =   40,
+     &           sNy =   40,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  226,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   92)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/LIG/SIZE.h_0499p_exch2
+++ b/presets/LIG/SIZE.h_0499p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (      
+     &           sNx =   25,
+     &           sNy =   28,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  499,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   92)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/LIG/SIZE.h_0854p_exch2
+++ b/presets/LIG/SIZE.h_0854p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (      
+     &           sNx =   20,
+     &           sNy =   20,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  854,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   92)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/NAD/SIZE.h_0278p_exch2
+++ b/presets/NAD/SIZE.h_0278p_exch2
@@ -1,0 +1,73 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C $Name: checkpoint66j $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   40,
+     &           sNy =   30,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  278,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   43)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/NAD/SIZE.h_0385p_exch2
+++ b/presets/NAD/SIZE.h_0385p_exch2
@@ -1,0 +1,73 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C $Name: checkpoint66j $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   28,
+     &           sNy =   30,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  385,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   43)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/NAD/SIZE.h_0535p_exch2
+++ b/presets/NAD/SIZE.h_0535p_exch2
@@ -1,0 +1,73 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C $Name: checkpoint66j $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   20,
+     &           sNy =   30,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  535,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   43)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/NAD/W2_EXCH2_SIZE.h
+++ b/presets/NAD/W2_EXCH2_SIZE.h
@@ -1,0 +1,48 @@
+CBOP
+C    !ROUTINE: W2_EXCH2_SIZE.h
+C    !INTERFACE:
+C    include W2_EXCH2_SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | W2_EXCH2_SIZE.h
+C     | Declare size of Wrapper2-Exch2 arrays
+C     *==========================================================*
+C     | Expected to be modified for unconventional configuration
+C     | (e.g., many blank-tiles) or specific topology.
+C     *==========================================================*
+CEOP
+
+C---   Size of Tiling topology structures
+C  W2_maxNbFacets   :: Maximum number of Facets (also and formerly called
+C                   :: "domains" or "sub-domains") of this topology.
+C  W2_maxNeighbours :: Maximum number of neighbours any tile has.
+C  W2_maxNbTiles    :: Maximum number of tiles (active+blank) in this topology
+C  W2_ioBufferSize  :: Maximum size of Single-CPU IO buffer.
+       INTEGER W2_maxNbFacets
+       INTEGER W2_maxNeighbours
+       INTEGER W2_maxNbTiles
+       INTEGER W2_ioBufferSize
+       INTEGER W2_maxXStackNx
+       INTEGER W2_maxXStackNy
+       INTEGER W2_maxYStackNx
+       INTEGER W2_maxYStackNy
+
+C---   Default values :
+C      (suitable for 6-face Cube-Sphere topology, compact global I/O format)
+C      W2_maxNbTiles = Nb of active tiles (=nSx*nSy*nPx*nPy) + Max_Nb_BlankTiles
+C      default assume a large Max_Nb_BlankTiles equal to Nb of active tiles
+C      resulting in doubling the tile number.
+       PARAMETER ( W2_maxNbFacets = 10 )
+       PARAMETER ( W2_maxNeighbours = 8 )
+       PARAMETER ( W2_maxNbTiles = nSx*nSy*nPx*nPy * 3 )
+       PARAMETER ( W2_ioBufferSize = W2_maxNbTiles*sNx*sNy )
+       PARAMETER ( W2_maxXStackNx = W2_maxNbTiles*sNx )
+       PARAMETER ( W2_maxXStackNy = W2_maxNbTiles*sNy )
+       PARAMETER ( W2_maxYStackNx = W2_maxNbTiles*sNx )
+       PARAMETER ( W2_maxYStackNy = W2_maxNbTiles*sNy )
+
+C- Note: Overestimating W2_maxNbFacets and, to less extent, W2_maxNeighbours
+C        have no or very little effects on memory footprint.
+C        overestimated W2_maxNbTiles does not have large effect, except
+C        through ioBufferSize (if related to, as here).
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/presets/SAD/SIZE.h_0299p_exch2
+++ b/presets/SAD/SIZE.h_0299p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   40,
+     &           sNy =   40,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  299,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   85)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SAD/SIZE.h_0444p_exch2
+++ b/presets/SAD/SIZE.h_0444p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   31,
+     &           sNy =   34,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  444,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   85)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SAD/SIZE.h_0675p_exch2
+++ b/presets/SAD/SIZE.h_0675p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   20,
+     &           sNy =   34,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  675,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   85)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SAR/SIZE.h_0503p_exch2
+++ b/presets/SAR/SIZE.h_0503p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   40,
+     &           sNy =   40,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  503,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   95)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SAR/SIZE.h_0827p_exch2
+++ b/presets/SAR/SIZE.h_0827p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   30,
+     &           sNy =   32,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  827,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   95)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SAR/SIZE.h_1174p_exch2
+++ b/presets/SAR/SIZE.h_1174p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   27,
+     &           sNy =   25,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy = 1174,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   95)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SIC/SIZE.h_0378p_exch2
+++ b/presets/SIC/SIZE.h_0378p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   40,
+     &           sNy =   40,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  378,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   99)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SIC/SIZE.h_0715p_exch2
+++ b/presets/SIC/SIZE.h_0715p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   23,
+     &           sNy =   36,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  715,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   99)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/SIC/SIZE.h_1264p_exch2
+++ b/presets/SIC/SIZE.h_1264p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   23,
+     &           sNy =   20,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy = 1264,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   99)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/TYR/SIZE.h_0263p_exch2
+++ b/presets/TYR/SIZE.h_0263p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   40,
+     &           sNy =   40,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  263,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   97)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/TYR/SIZE.h_0503p_exch2
+++ b/presets/TYR/SIZE.h_0503p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   24,
+     &           sNy =   34,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy =  503,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   97)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+

--- a/presets/TYR/SIZE.h_1006p_exch2
+++ b/presets/TYR/SIZE.h_1006p_exch2
@@ -1,0 +1,72 @@
+C $Header: /u/gcmpack/MITgcm/model/inc/SIZE.h,v 1.28 2009/05/17 21:15:07 jmc Exp $
+C
+C  These lines are here to deliberately cause a compile-time error.
+C  If you see these lines in your .F files or the compiler shows them
+C  as an error then it means you have not placed your configuration
+C  files in the appropriate place.
+C  You need to place you own copy of SIZE.h in the include
+C  path for the model, and comment out these lines.
+C
+C
+CBOP
+C    !ROUTINE: SIZE.h
+C    !INTERFACE:
+C    include SIZE.h
+C    !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SIZE.h Declare size of underlying computational grid.     
+C     *==========================================================*
+C     | The design here support a three-dimensional model grid    
+C     | with indices I,J and K. The three-dimensional domain      
+C     | is comprised of nPx*nSx blocks of size sNx along one axis 
+C     | nPy*nSy blocks of size sNy along another axis and one     
+C     | block of size Nz along the final axis.                    
+C     | Blocks have overlap regions of size OLx and OLy along the 
+C     | dimensions that are subdivided.                           
+C     *==========================================================*
+C     \ev
+CEOP
+C     Voodoo numbers controlling data layout.
+C     sNx :: No. X points in sub-grid.
+C     sNy :: No. Y points in sub-grid.
+C     OLx :: Overlap extent in X.
+C     OLy :: Overlat extent in Y.
+C     nSx :: No. sub-grids in X.
+C     nSy :: No. sub-grids in Y.
+C     nPx :: No. of processes to use in X.
+C     nPy :: No. of processes to use in Y.
+C     Nx  :: No. points in X for the total domain.
+C     Ny  :: No. points in Y for the total domain.
+C     Nr  :: No. points in Z for full process domain.
+      INTEGER sNx
+      INTEGER sNy
+      INTEGER OLx
+      INTEGER OLy
+      INTEGER nSx
+      INTEGER nSy
+      INTEGER nPx
+      INTEGER nPy
+      INTEGER Nx
+      INTEGER Ny
+      INTEGER Nr
+      PARAMETER (
+     &           sNx =   20,
+     &           sNy =   20,
+     &           OLx =    4,
+     &           OLy =    4,
+     &           nSx =    1,
+     &           nSy =    1,
+     &           nPx =    1,
+     &           nPy = 1006,
+     &           Nx  = sNx*nSx*nPx,
+     &           Ny  = sNy*nSy*nPy,
+     &           Nr  =   97)
+
+C     MAX_OLX :: Set to the maximum overlap region size of any array
+C     MAX_OLY    that will be exchanged. Controls the sizing of exch
+C                routine buffers.
+      INTEGER MAX_OLX
+      INTEGER MAX_OLY
+      PARAMETER ( MAX_OLX = OLx,
+     &            MAX_OLY = OLy )
+


### PR DESCRIPTION
Added the exch2 package in pkg_groups, new SIZE.h* (also W2_EXCH2_SIZE.h for NAD, which has more land tiles than water tiles).